### PR TITLE
Fixed a situation where for an empty (no data) session, COOKIE was no…

### DIFF
--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -61,13 +61,13 @@ class PhpSessionPersistence implements SessionPersistenceInterface
         return $response;
     }
 
-    private function startSession(string $id) : void
+    private function startSession(string $id, array $options = []) : void
     {
         session_id($id);
-        session_start([
+        session_start(array_merge([
             'use_cookies'      => false,
             'use_only_cookies' => true,
-        ]);
+        ], $options));
     }
 
     /**
@@ -78,8 +78,9 @@ class PhpSessionPersistence implements SessionPersistenceInterface
     private function regenerateSession() : void
     {
         session_commit();
-        ini_set('session.use_strict_mode', 0);
-        $this->startSession($this->generateSessionId());
+        $this->startSession($this->generateSessionId(), [
+            'use_strict_mode' => false,
+        ]);
     }
 
     /**

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -70,16 +70,6 @@ class PhpSessionPersistenceTest extends TestCase
         $this->assertSame('use-this-id', $id);
     }
 
-    public function testPersistSessionReturnsOriginalResposneIfSessionIsEmpty()
-    {
-        $this->startSession();
-        $session = new Session([]);
-        $response = new Response();
-
-        $returnedResponse = $this->persistence->persistSession($session, $response);
-        $this->assertSame($response, $returnedResponse);
-    }
-
     public function testPersistSessionReturnsResponseWithSetCookieHeaderIfSessionHasContents()
     {
         $this->startSession();

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -77,23 +77,6 @@ class PhpSessionPersistenceTest extends TestCase
         $this->assertSame('use-this-id', $id);
     }
 
-    public function testPersistSessionReturnsResponseWithSetCookieHeaderIfSessionHasContents()
-    {
-        $this->startSession();
-        $session = new Session(['foo' => 'bar']);
-        $response = new Response();
-
-        $returnedResponse = $this->persistence->persistSession($session, $response);
-        $this->assertNotSame($response, $returnedResponse);
-
-        $setCookie = FigResponseCookies::get($returnedResponse, session_name());
-        $this->assertInstanceOf(SetCookie::class, $setCookie);
-        $this->assertSame(session_id(), $setCookie->getValue());
-        $this->assertSame(ini_get('session.cookie_path'), $setCookie->getPath());
-
-        $this->assertSame($session->toArray(), $_SESSION);
-    }
-
     public function testPersistSessionGeneratesCookieWithNewSessionIdIfSessionWasRegenerated()
     {
         $this->startSession('original-id');

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -133,4 +133,12 @@ class PhpSessionPersistenceTest extends TestCase
         $this->assertSame(session_id(), $setCookie->getValue());
         $this->assertSame(ini_get('session.cookie_path'), $setCookie->getPath());
     }
+
+    public function testPersistSessionIfSessionHasContents()
+    {
+        $this->startSession();
+        $session = new Session(['foo' => 'bar']);
+        $this->persistence->persistSession($session, new Response);
+        $this->assertSame($session->toArray(), $_SESSION);
+    }
 }


### PR DESCRIPTION
The error is visible only on the empty session data, it simply does not install the required COOKIE, if they did not exist. If the session has some data, there is no error.