### PR TITLE
Updates to allow zend-expressive-session 1.0-dev releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.1",
         "ext-session": "*",
         "dflydev/fig-cookies": "^1.0",
-        "zendframework/zend-expressive-session": "^0.1.0"
+        "zendframework/zend-expressive-session": "^0.1.0 || ^1.0.0-dev || ^1.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "01323d32afb3e5b0b01192cdeb202848",
+    "content-hash": "45c1978ba57b33c95124562cbc7b4159",
     "packages": [
         {
             "name": "dflydev/fig-cookies",
@@ -108,6 +108,7 @@
                 "request",
                 "response"
             ],
+            "abandoned": "http-interop/http-server-middleware",
             "time": "2017-01-14T15:23:42+00:00"
         },
         {
@@ -1882,7 +1883,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "zendframework/zend-expressive-session": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
This _should_ pose no issues, as this is an adapter, and functionality has not changed in the alpha releases; testing to verify, however!