### PR TITLE
Fix handling of reset session not resetting the cookie.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#8](https://github.com/zendframework/zend-expressive-session-ext/pull/8)
+    Fixes handling of reset session not resetting the cookie.
 
 ## 1.0.0 - 2018-03-15
 

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -62,7 +62,7 @@ class PhpSessionPersistence implements SessionPersistenceInterface
         $_SESSION = $session->toArray();
         session_write_close();
 
-        if ($this->cookie === null) {
+        if (empty($this->cookie)) {
             $sessionCookie = SetCookie::create(session_name())
                 ->withValue(session_id())
                 ->withPath(ini_get('session.cookie_path'));

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -62,7 +62,7 @@ class PhpSessionPersistence implements SessionPersistenceInterface
         $_SESSION = $session->toArray();
         session_write_close();
 
-        if (empty($this->cookie)) {
+        if ($this->cookie === null) {
             $sessionCookie = SetCookie::create(session_name())
                 ->withValue(session_id())
                 ->withPath(ini_get('session.cookie_path'));
@@ -93,6 +93,7 @@ class PhpSessionPersistence implements SessionPersistenceInterface
     private function regenerateSession() : void
     {
         session_commit();
+        $this->cookie = null;
         $this->startSession($this->generateSessionId(), [
             'use_strict_mode' => false,
         ]);


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
Use expressive-session-ext with expressive-authentication
  - [x] Detail the original, incorrect behavior.
Logon never completes. User never manages to log in.
  - [x] Detail the new, expected behavior.
User can log in.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.

Reset of session did not reset its cookie along with it. Thus, request cookie was still using original session ID, while SessionPersistor was using its own new session id for future responses. This worked prior to #1 because other libraries assumed that empty session did not set a cookie, therefore further assuming that resetting session elsewhere would be safe (specifically, [not-logged in user = no cookie] => [logging in = setting cookie for the first time]).

This should have been caught by the `testPersistSessionGeneratesCookieWithNewSessionIdIfSessionWasRegenerated` test. However, the test never actually created a cookie with old session-id, so it never tested the actual life cycle of "old cookie->reset session-> new cookie". Only creating cookie for the first time after reset was false positive.
