### PR TITLE
preserve required php session  options

### DIFF
--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -79,10 +79,10 @@ class PhpSessionPersistence implements SessionPersistenceInterface
     private function startSession(string $id, array $options = []) : void
     {
         session_id($id);
-        session_start(array_merge([
+        session_start([
             'use_cookies'      => false,
             'use_only_cookies' => true,
-        ], $options));
+        ] + $options);
     }
 
     /**


### PR DESCRIPTION
make sure that `use_cookies` and `use_only_cookies` options are not overwritten by custom options
