### PR TITLE
Cache limiter support attempt

### DIFF
--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -194,14 +194,8 @@ class PhpSessionPersistence implements SessionPersistenceInterface
      */
     private function getLastModified(string $filename) : ?string
     {
-        if ($filename
-            && is_file($filename)
-        ) {
-            $mtime = @filemtime($filename);
-            if (false === $mtime) {
-                return null;
-            }
-            return gmdate(self::HTTP_DATE_FORMAT, $mtime);
+        if ($filename && is_file($filename)) {
+            return gmdate(self::HTTP_DATE_FORMAT, filemtime($filename));
         }
 
         return null;

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -144,7 +144,7 @@ class PhpSessionPersistence implements SessionPersistenceInterface
      */
     private function generateCacheHeaders(string $cacheLimiter = null) : array
     {
-        if (!$cacheLimiter) {
+        if (! $cacheLimiter) {
             return [];
         }
 

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -186,7 +186,7 @@ class PhpSessionPersistence implements SessionPersistenceInterface
         }
 
         $maxAge       = 60 * $this->cacheExpire;
-        $lastModified = $this->getLastModified($_SERVER['SCRIPT_FILENAME'] ?? '');
+        $lastModified = $this->getLastModified();
 
         // cache_limiter: 'public'
         if ('public' === $this->cacheLimiter) {

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -217,7 +217,6 @@ class PhpSessionPersistence implements SessionPersistenceInterface
      * Return the Last-Modified header line based on the request's script file
      * modified time. If no script file could be derived from the request we use
      * this class file modification time as fallback.
-     * 
      * @return string|false
      */
     private function getLastModified()

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -140,15 +140,11 @@ class PhpSessionPersistence implements SessionPersistenceInterface
 
     /**
      * Generate cache headers for a given session cache_limiter value.
-     * @param string|null $cacheLimiter
+     * @param string $cacheLimiter
      * @param int $cacheExpire
      */
-    private function generateCacheHeaders(string $cacheLimiter = null, int $cacheExpire = 0) : array
+    private function generateCacheHeaders(string $cacheLimiter, int $cacheExpire = 0) : array
     {
-        if (! $cacheLimiter) {
-            return [];
-        }
-
         if ($cacheLimiter === 'nocache') {
             return [
                 'Expires'       => self::CACHE_PAST_DATE,

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -91,7 +91,7 @@ class PhpSessionPersistence implements SessionPersistenceInterface
                 if ($this->responseAlreadyHasCacheHeaders($response)) {
                     return $response;
                 }
-                $cacheHeaders = $this->generateCacheHeaders($this->cacheLimiter);
+                $cacheHeaders = $this->generateCacheHeaders($this->cacheLimiter, $this->cacheExpire);
                 foreach ($cacheHeaders as $name => $value) {
                     $response = $response->withHeader($name, $value);
                 }
@@ -141,8 +141,9 @@ class PhpSessionPersistence implements SessionPersistenceInterface
     /**
      * Generate cache headers for a given session cache_limiter value.
      * @param string|null $cacheLimiter
+     * @param int $cacheExpire
      */
-    private function generateCacheHeaders(string $cacheLimiter = null) : array
+    private function generateCacheHeaders(string $cacheLimiter = null, int $cacheExpire = 0) : array
     {
         if (! $cacheLimiter) {
             return [];
@@ -157,7 +158,7 @@ class PhpSessionPersistence implements SessionPersistenceInterface
         }
 
         $headers = [];
-        $maxAge  = 60 * $this->cacheExpire;
+        $maxAge  = 60 * $cacheExpire;
 
         if ($cacheLimiter === 'public') {
             $headers = [

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -178,7 +178,8 @@ class PhpSessionPersistence implements SessionPersistenceInterface
             return [];
         }
 
-        $lastModified = $this->getLastModified();
+        $script = $_SERVER['SCRIPT_FILENAME'] ?? '';
+        $lastModified = $this->getLastModified($script);
         if ($lastModified) {
             $headers['Last-Modified'] = $lastModified;
         }
@@ -189,11 +190,14 @@ class PhpSessionPersistence implements SessionPersistenceInterface
     /**
      * Return the Last-Modified header line based on script name mtime
      * @return string|null
+     * @return string|null
      */
-    private function getLastModified()
+    private function getLastModified(string $filename) : ?string
     {
-        if (isset($_SERVER['SCRIPT_FILENAME'])) {
-            $mtime = @filemtime($_SERVER['SCRIPT_FILENAME']);
+        if ($filename
+            && is_file($filename)
+        ) {
+            $mtime = @filemtime($filename);
             if (false === $mtime) {
                 return null;
             }
@@ -208,7 +212,7 @@ class PhpSessionPersistence implements SessionPersistenceInterface
      * @param ResponseInterface $response
      * @return bool
      */
-    private function responseAlreadyHasCacheHeaders(ResponseInterface $response)
+    private function responseAlreadyHasCacheHeaders(ResponseInterface $response) : bool
     {
         return (
                $response->hasHeader('Expires')

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -123,8 +123,6 @@ class PhpSessionPersistence implements SessionPersistenceInterface
                     $response = $response->withHeader($name, $value);
                 }
             }
-
-            return $response;
         }
 
         return $response;

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -217,6 +217,8 @@ class PhpSessionPersistence implements SessionPersistenceInterface
      * Return the Last-Modified header line based on the request's script file
      * modified time. If no script file could be derived from the request we use
      * this class file modification time as fallback.
+     * 
+     * @return string|false
      */
     private function getLastModified()
     {

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -156,7 +156,7 @@ class PhpSessionPersistence implements SessionPersistenceInterface
     private function generateCacheHeaders(string $cacheLimiter, int $cacheExpire = 0) : array
     {
         // Unsupported cache_limiter
-        if (!isset(self::$supported_cache_limiters[$cacheLimiter])) {
+        if (! isset(self::$supported_cache_limiters[$cacheLimiter])) {
             return [];
         }
 

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -196,9 +196,6 @@ class PhpSessionPersistenceTest extends TestCase
         $response = $persistence->persistSession($session, new Response());
         $expiresMax = time() + $maxAge;
 
-        $expiresMin = time() + $maxAge - 1;
-        $expiresMax = time() + $maxAge + 1;
-
         $control = sprintf('public, max-age=%d', $maxAge);
         $expires = $response->getHeaderLine('Expires');
         $expires = strtotime($expires);

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -263,9 +263,9 @@ class PhpSessionPersistenceTest extends TestCase
         $session  = new Session(['foo' => 'bar']);
         $response = $persistence->persistSession($session, $response);
 
-        $this->assertSame($response->getHeaderLine('Pragma'), '');
-        $this->assertSame($response->getHeaderLine('Expires'), '');
-        $this->assertSame($response->getHeaderLine('Cache-Control'), '');
+        $this->assertFalse($response->hasHeader('Pragma'));
+        $this->assertFalse($response->hasHeader('Expires'));
+        $this->assertFalse($response->hasHeader('Cache-Control'));
     }
 
     public function testPersistSessionReturnsExpectedResponseWithLastModifiedHeader()
@@ -316,6 +316,22 @@ class PhpSessionPersistenceTest extends TestCase
     {
         $this->startSession(null, [
             'cache_limiter' => '',
+        ]);
+
+        $persistence = new PhpSessionPersistence();
+
+        $session  = new Session(['foo' => 'bar']);
+        $response = $persistence->persistSession($session, new Response());
+
+        $this->assertFalse($response->hasHeader('Pragma'));
+        $this->assertFalse($response->hasHeader('Expires'));
+        $this->assertFalse($response->hasHeader('Cache-Control'));
+    }
+
+    public function testPersistSessionReturnsExpectedResponseWithoutAddedCacheHeadersIfUnsupportedCacheLimiter()
+    {
+        $this->startSession(null, [
+            'cache_limiter' => 'unsupported',
         ]);
 
         $persistence = new PhpSessionPersistence();

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -267,4 +267,20 @@ class PhpSessionPersistenceTest extends TestCase
         $this->assertSame($response->getHeaderLine('Expires'), '');
         $this->assertSame($response->getHeaderLine('Cache-Control'), '');
     }
+
+    public function testPersistSessionReturnsExpectedResponseWithoutAddedCacheHeadersIfEmptyCacheLimiter()
+    {
+        $this->startSession(null, [
+            'cache_limiter' => '',
+        ]);
+
+        $persistence = new PhpSessionPersistence();
+
+        $session  = new Session(['foo' => 'bar']);
+        $response = $persistence->persistSession($session, new Response());
+
+        $this->assertSame($response->getHeaderLine('Pragma'), '');
+        $this->assertSame($response->getHeaderLine('Expires'), '');
+        $this->assertSame($response->getHeaderLine('Cache-Control'), '');
+    }
 }


### PR DESCRIPTION
Inject cache headers based on cache_limiter value, while removing the automatic job from the php engine.

The php engine automatically sends cache-http-headers based on the values of `session.cache_limiter`, `session.cache_expire` ini/session_start settings and the script last mtime.

The idea is to steal the value of `session.cache_limiter` inside the constructor and set an empty cache_limiter when starting the session, thus disabling the automatic headers.

Then we recreate the logic of the zend-engine to build the headers ourselves and inject them into the response.

TODO/TOCHECK
- find a better/proper way to check the running script mtime
- decide if/when to inject the cache header: right now if a cache header is found we assume that it was added programmatically in an internal middleware layer, so we skip injecting any of them. What should we do: override-headers? add-(multi-value)-headers? 