### PR TITLE
fix unsent cookie issue

### DIFF
--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -61,9 +61,9 @@ class PhpSessionPersistence implements SessionPersistenceInterface
         $_SESSION = $session->toArray();
         session_write_close();
 
-        if (empty($this->cookie)) {
+        if ($this->cookie) {
             $sessionCookie = SetCookie::create(session_name())
-                ->withValue(session_id())
+                ->withValue($this->cookie)
                 ->withPath(ini_get('session.cookie_path'));
 
             return FigResponseCookies::set($response, $sessionCookie);
@@ -92,8 +92,8 @@ class PhpSessionPersistence implements SessionPersistenceInterface
     private function regenerateSession() : void
     {
         session_write_close();
-        $this->cookie = null;
-        $this->startSession($this->generateSessionId(), [
+        $this->cookie = $this->generateSessionId();
+        $this->startSession($this->cookie, [
             'use_strict_mode' => false,
         ]);
     }


### PR DESCRIPTION
@weierophinney 

Does this make sense to You?

The `$cookie` internal property gets the value from the request `session_name()` cookie, if any.
If no request cookie value is found  it gets a freshly generated session id value
In any case `$cookie` has the value for the session id and its used to start the session

When returning the response we must include a set-cookie header with the same value (and name equal to session_name())

If the session is regenerated a new session id value is created and that value (saved into $cookie) must be passed into the response cookie header, instead of the old session id.

kind regards,

https://github.com/zendframework/zend-expressive-session-ext/issues/10