### PR TITLE
correct type annotation for $cookie

### DIFF
--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -41,7 +41,7 @@ use function session_write_close;
  */
 class PhpSessionPersistence implements SessionPersistenceInterface
 {
-    /** @var Cookie */
+    /** @var string|null */
     private $cookie;
 
     public function initializeSessionFromRequest(ServerRequestInterface $request) : SessionInterface


### PR DESCRIPTION
$cookie is the Cookie value, not a Cookie instance.
Q: should we just rename it to $sessionId for clarity?
