### PR TITLE
fix regenerated session test case

### DIFF
--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -93,7 +93,7 @@ class PhpSessionPersistenceTest extends TestCase
         /** @var ServerRequestInterface $request */
         $request = FigRequestCookies::set(
             new ServerRequest(),
-            Cookie::create($sessionName, 'use-this-id')
+            Cookie::create($sessionName, 'original-id')
         );
 
         // first request of original session cookie


### PR DESCRIPTION
The initial session id should have the value `original-id`: the purpose of the test is to prove that after regeneration the new session_id differs from it.
