### PR TITLE
Ensure cookie is set when a new session is started

### DIFF
--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -92,8 +92,12 @@ class PhpSessionPersistence implements SessionPersistenceInterface
     public function initializeSessionFromRequest(ServerRequestInterface $request) : SessionInterface
     {
         $this->scriptFile = $request->getServerParams()['SCRIPT_FILENAME'] ?? __FILE__;
-        $this->cookie = FigRequestCookies::get($request, session_name())->getValue();
-        $id = $this->cookie ?: $this->generateSessionId();
+        $id = $this->cookie = FigRequestCookies::get($request, session_name())->getValue();
+
+        if (! $id) {
+            $id = $this->cookie = $this->generateSessionId();
+        }
+
         $this->startSession($id);
         return new Session($_SESSION);
     }

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -422,4 +422,16 @@ class PhpSessionPersistenceTest extends TestCase
 
         $this->restoreOriginalSessionIniSettings($ini);
     }
+
+    public function testPersistSessionReturnsCookieForNewSession(): void
+    {
+        $persistence = new PhpSessionPersistence();
+        $request = new ServerRequest();
+        $session = $persistence->initializeSessionFromRequest($request);
+
+        $response = new Response();
+        $response = $persistence->persistSession($session, $response);
+
+        $this->assertNotEmpty($response->getHeaderLine('Set-Cookie'));
+    }
 }


### PR DESCRIPTION
Proposed fix for #19.

PersistSession was not returning a cookie for new sessions. To fix, if there is not a session cookie in the request, ensure it is generated and attached.
