### PR TITLE
Generate a session id for new sessions with data

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2017, Zend Technologies USA, Inc.
+Copyright (c) 2017-2018, Zend Technologies USA, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -7,7 +7,6 @@
 
 namespace Zend\Expressive\Session\Ext;
 
-use Dflydev\FigCookies\FigCookies\Cookie;
 use Dflydev\FigCookies\FigRequestCookies;
 use Dflydev\FigCookies\FigResponseCookies;
 use Dflydev\FigCookies\SetCookie;

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -102,7 +102,7 @@ class PhpSessionPersistence implements SessionPersistenceInterface
         // Regenerate if the session is marked as regenerated
         // Regenerate if there is no cookie id set but the session has changed (new session with data)
         if ($session->isRegenerated()
-            || ($session->hasChanged() && ! $this->cookie)) {
+            || (! $this->cookie && $session->hasChanged())) {
             $this->regenerateSession();
         }
 

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-session-ext for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-session-ext/blob/master/LICENSE.md New BSD License
  */
 
@@ -100,7 +100,10 @@ class PhpSessionPersistence implements SessionPersistenceInterface
 
     public function persistSession(SessionInterface $session, ResponseInterface $response) : ResponseInterface
     {
-        if ($session->isRegenerated()) {
+        // Regenerate if the session is marked as regenerated
+        // Regenerate if there is no cookie id set but the session has changed (new session with data)
+        if ($session->isRegenerated()
+            || ($session->hasChanged() && ! $this->cookie)) {
             $this->regenerateSession();
         }
 

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -15,7 +15,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\Session\Session;
 use Zend\Expressive\Session\SessionInterface;
 use Zend\Expressive\Session\SessionPersistenceInterface;
-
 use function array_merge;
 use function bin2hex;
 use function filemtime;
@@ -102,7 +101,8 @@ class PhpSessionPersistence implements SessionPersistenceInterface
         // Regenerate if the session is marked as regenerated
         // Regenerate if there is no cookie id set but the session has changed (new session with data)
         if ($session->isRegenerated()
-            || (! $this->cookie && $session->hasChanged())) {
+            || (! $this->cookie && $session->hasChanged())
+        ) {
             $this->regenerateSession();
         }
 

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\Session\Session;
 use Zend\Expressive\Session\SessionInterface;
 use Zend\Expressive\Session\SessionPersistenceInterface;
+
 use function array_merge;
 use function bin2hex;
 use function filemtime;

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -198,7 +198,7 @@ class PhpSessionPersistenceTest extends TestCase
     {
         $this->startSession();
         $session = new Session(['foo' => 'bar']);
-        $this->persistence->persistSession($session, new Response);
+        $this->persistence->persistSession($session, new Response());
         $this->assertSame($session->toArray(), $_SESSION);
     }
 

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-session-ext for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-session-ext/blob/master/LICENSE.md New BSD License
  */
 
@@ -421,5 +421,31 @@ class PhpSessionPersistenceTest extends TestCase
         $this->assertFalse($response->hasHeader('Cache-Control'));
 
         $this->restoreOriginalSessionIniSettings($ini);
+    }
+
+    public function testCookiesNotSetWithoutRegenerate(): void
+    {
+        $persistence = new PhpSessionPersistence();
+        $request = new ServerRequest();
+        $session = $persistence->initializeSessionFromRequest($request);
+
+        $response = new Response();
+        $response = $persistence->persistSession($session, $response);
+
+        $this->assertEmpty($response->getHeaderLine('Set-Cookie'));
+    }
+
+    public function testCookiesSetWithoutRegenerate(): void
+    {
+        $persistence = new PhpSessionPersistence();
+        $request = new ServerRequest();
+        $session = $persistence->initializeSessionFromRequest($request);
+
+        $session->set('foo', 'bar');
+
+        $response = new Response();
+        $response = $persistence->persistSession($session, $response);
+
+        $this->assertNotEmpty($response->getHeaderLine('Set-Cookie'));
     }
 }

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -423,7 +423,7 @@ class PhpSessionPersistenceTest extends TestCase
         $this->restoreOriginalSessionIniSettings($ini);
     }
 
-    public function testCookiesNotSetWithoutRegenerate(): void
+    public function testCookiesNotSetWithoutRegenerate()
     {
         $persistence = new PhpSessionPersistence();
         $request = new ServerRequest();
@@ -432,10 +432,10 @@ class PhpSessionPersistenceTest extends TestCase
         $response = new Response();
         $response = $persistence->persistSession($session, $response);
 
-        $this->assertEmpty($response->getHeaderLine('Set-Cookie'));
+        $this->assertFalse($response->hasHeader('Set-Cookie'));
     }
 
-    public function testCookiesSetWithoutRegenerate(): void
+    public function testCookiesSetWithoutRegenerate()
     {
         $persistence = new PhpSessionPersistence();
         $request = new ServerRequest();


### PR DESCRIPTION
If a new session was generated, the session id isn't stored. On persistence it doesn't (re)generate an id which is expected. You only need a session if there is data to store. However there is never a check performed for changed data session.

This PR tries to fix that and checks if session data is changed and generates a session id if there wasn't one. This makes sure that data is stored if there wasn't a session yet.