### PR TITLE
Use `session.cookie_lifetime` value when creating the session cookie.

### DIFF
--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -115,6 +115,10 @@ class PhpSessionPersistence implements SessionPersistenceInterface
                 ->withValue($this->cookie)
                 ->withPath(ini_get('session.cookie_path'));
 
+            if ($cookieLifetime = (int) ini_get('session.cookie_lifetime')) {
+                $sessionCookie = $sessionCookie->withExpires(time() + $cookieLifetime);
+            }
+
             $response = FigResponseCookies::set($response, $sessionCookie);
 
             if (! $this->cacheLimiter || $this->responseAlreadyHasCacheHeaders($response)) {


### PR DESCRIPTION
Today I had the need to have the lifetime of the session cookie to be <> 0, i.e cookie is removed after the user agent is shut down.
This PR allow to use the `session.cookie_lifetime` to customise the cookie's expiration.