### PR TITLE
add `dflydev/fig-cookies` ^2.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.1",
         "ext-session": "*",
-        "dflydev/fig-cookies": "^1.0",
+        "dflydev/fig-cookies": "^1.0 || ^2.0",
         "zendframework/zend-expressive-session": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
so it can work with other session related component, eg: `zend-expressive-session-cache` that require `"dflydev/fig-cookies": "^1.0.2 || ^2.0"` which if that required first, this component adapter won't be installable.
