### PR TITLE
Use session persistence duration when available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ matrix:
     - php: 7.2
       env:
         - DEPS=latest
+    - php: nightly
+      env:
+        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 1.3.0 - TBD
+## 1.3.0 - 2018-10-31
 
 ### Added
 
-- Nothing.
+- [#29](https://github.com/zendframework/zend-expressive-session-ext/pull/29) adds support for the zend-expressive-session `SessionCookiePersistenceInterface`.
+  Specifically, `PhpSessionPersistence::persistSession()` now consults the
+  session instance for a requested session duration, using it if present, even
+  if a `session.cookie_lifetime` INI value was previously set.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,28 +24,6 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - Nothing.
 
-## 1.2.1 - TBD
-
-### Added
-
-- Nothing.
-
-### Changed
-
-- Nothing.
-
-### Deprecated
-
-- Nothing.
-
-### Removed
-
-- Nothing.
-
-### Fixed
-
-- Nothing.
-
 ## 1.2.0 - 2018-09-12
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.1",
         "ext-session": "*",
         "dflydev/fig-cookies": "^1.0 || ^2.0",
-        "zendframework/zend-expressive-session": "^1.1"
+        "zendframework/zend-expressive-session": "^1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae13e0afdd691c1647efe0ff883eaee7",
+    "content-hash": "ebca14598bb47ff951a5739f94ce1461",
     "packages": [
         {
             "name": "dflydev/fig-cookies",
@@ -265,16 +265,16 @@
         },
         {
             "name": "zendframework/zend-expressive-session",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-session.git",
-                "reference": "1bcb8e7869b47e30f1ba692f15e52481d1d550db"
+                "reference": "de67a644d34848451e137919b7018161f7dced13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-session/zipball/1bcb8e7869b47e30f1ba692f15e52481d1d550db",
-                "reference": "1bcb8e7869b47e30f1ba692f15e52481d1d550db",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-session/zipball/de67a644d34848451e137919b7018161f7dced13",
+                "reference": "de67a644d34848451e137919b7018161f7dced13",
                 "shasum": ""
             },
             "require": {
@@ -297,8 +297,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev",
-                    "dev-develop": "1.2.x-dev"
+                    "dev-master": "1.2.x-dev",
+                    "dev-develop": "1.3.x-dev"
                 },
                 "zf": {
                     "config-provider": "Zend\\Expressive\\Session\\ConfigProvider"
@@ -323,7 +323,7 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2018-09-12T15:16:19+00:00"
+            "time": "2018-10-30T21:08:51+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This patch adapts `PhpSessionPersistence` to use the `SessionCookiePersistenceInterface::persistSessionFor()` method introduced in zend-expressive-session 1.2.0 in order to set the `Expires` directive of the session cookie.