### PR TITLE
Add support for session cookie domain, secure, and http-only flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#31](https://github.com/zendframework/zend-expressive-session-ext/pull/31) adds support for the `session.cookie_domain`, `session.cookie_httponly`,
+  and `session.cookie_secure` INI values when creating the `Set-Cookie` header
+  value.
 
 ### Changed
 

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -120,7 +120,10 @@ class PhpSessionPersistence implements SessionPersistenceInterface
 
         $sessionCookie = SetCookie::create(session_name())
             ->withValue($id)
-            ->withPath(ini_get('session.cookie_path'));
+            ->withPath(ini_get('session.cookie_path'))
+            ->withDomain(ini_get('session.cookie_domain'))
+            ->withSecure(ini_get('session.cookie_secure'))
+            ->withHttpOnly(ini_get('session.cookie_httponly'));
 
         if ($cookieLifetime = $this->getCookieLifetime($session)) {
             $sessionCookie = $sessionCookie->withExpires(time() + $cookieLifetime);

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -164,6 +164,11 @@ class PhpSessionPersistenceTest extends TestCase
         $this->assertInstanceOf(SetCookie::class, $setCookie);
         $this->assertSame(session_id(), $setCookie->getValue());
         $this->assertSame(ini_get('session.cookie_path'), $setCookie->getPath());
+
+        // @see https://github.com/zendframework/zend-expressive-session-ext/pull/31
+        $this->assertSame(ini_get('session.cookie_domain') ?: null, $setCookie->getDomain());
+        $this->assertSame((bool) ini_get('session.cookie_secure'), $setCookie->getSecure());
+        $this->assertSame((bool) ini_get('session.cookie_httponly'), $setCookie->getHttpOnly());
     }
 
     /**


### PR DESCRIPTION
This patch builds off of smalot/zend-expressive-session-ext#2, adding assertions to an existing test to validate that the appropriate flags for the session cookie domain, secure status, and http-only status are set appropriately.

It adds support for the following INI flags/values:

- `session.cookie_domain`
- `session.cookie_httponly`
- `session.cookie_secure`

Fixes #30 