### PR TITLE
Swaps php: nightly for php: 7.3 in test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,13 @@ matrix:
     - php: 7.2
       env:
         - DEPS=latest
-    - php: nightly
+    - php: 7.3
+      env:
+        - DEPS=lowest
+    - php: 7.3
+      env:
+        - DEPS=locked
+    - php: 7.3
       env:
         - DEPS=latest
 


### PR DESCRIPTION
Nightly now targest 8.0, which is unstable; this adds 7.3 officially to the matrix.