### PR TITLE
Fixed error with ID for new sessions

### DIFF
--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -92,7 +92,7 @@ class PhpSessionPersistence implements SessionPersistenceInterface
         $sessionId = FigRequestCookies::get($request, session_name())->getValue() ?? '';
         $id = $sessionId ?: $this->generateSessionId();
         $this->startSession($id);
-        return new Session($_SESSION, $sessionId);
+        return new Session($_SESSION, $id);
     }
 
     public function persistSession(SessionInterface $session, ResponseInterface $response) : ResponseInterface

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -113,7 +113,7 @@ class PhpSessionPersistence implements SessionPersistenceInterface
         $expires = $cookieLifetime ? time() + $cookieLifetime : 0;
 
         // Set the COOKIE if necessary
-        if (empty($this->cookie) || $cookieLifetime) {
+        if (empty($this->cookie) || $session->isRegenerated() || $cookieLifetime) {
             $sessionCookie = SetCookie::create(session_name())
                 ->withValue($id)
                 ->withPath(ini_get('session.cookie_path'))

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -156,6 +156,7 @@ class PhpSessionPersistenceTest extends TestCase
     {
         $request = $this->createSessionCookieRequest('use-this-id');
         $session = $this->persistence->initializeSessionFromRequest($request);
+        $session->persistSessionFor(300); // This is in order to work out the conditions for sending the COOKIE
 
         $response = new Response();
         $returnedResponse = $this->persistence->persistSession($session, $response);

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -172,19 +172,6 @@ class PhpSessionPersistenceTest extends TestCase
         $this->assertSame((bool) ini_get('session.cookie_httponly'), $setCookie->getHttpOnly());
     }
 
-    /**
-     * If Session COOKIE is not present, persistSession() method must return the original Response
-     */
-    public function testPersistSessionReturnsOriginalResponseIfNoSessionCookiePresent()
-    {
-        $this->startSession();
-        $session = new Session([]);
-        $response = new Response();
-
-        $returnedResponse = $this->persistence->persistSession($session, $response);
-        $this->assertSame($response, $returnedResponse);
-    }
-
     public function testPersistSessionIfSessionHasContents()
     {
         $this->startSession();
@@ -424,7 +411,7 @@ class PhpSessionPersistenceTest extends TestCase
         $this->restoreOriginalSessionIniSettings($ini);
     }
 
-    public function testCookiesNotSetWithoutRegenerate()
+    public function testCookiesSetWithEmptySessionDataWithoutRegenerate()
     {
         $persistence = new PhpSessionPersistence();
         $request = new ServerRequest();
@@ -433,10 +420,10 @@ class PhpSessionPersistenceTest extends TestCase
         $response = new Response();
         $response = $persistence->persistSession($session, $response);
 
-        $this->assertFalse($response->hasHeader('Set-Cookie'));
+        $this->assertNotEmpty($response->getHeaderLine('Set-Cookie'));
     }
 
-    public function testCookiesSetWithoutRegenerate()
+    public function testCookiesSetWithSessionDataWithoutRegenerate()
     {
         $persistence = new PhpSessionPersistence();
         $request = new ServerRequest();


### PR DESCRIPTION
The mistake is that instead of $id, which we checked and generated above, using $sessionId, which is taken directly from the COOKIE and for which a new session may not exist.