### PR TITLE
fix lifetime override test cases

### DIFF
--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -525,11 +525,17 @@ class PhpSessionPersistenceTest extends TestCase
         $lifetime = 300;
         $session->persistSessionFor($lifetime);
 
+        $expiresMin = time() + $lifetime;
         $response = $persistence->persistSession($session, new Response());
+        $expiresMax = time() + $lifetime;
 
         $setCookie = FigResponseCookies::get($response, session_name());
         $this->assertInstanceOf(SetCookie::class, $setCookie);
-        $this->assertSame(time() + $lifetime, $setCookie->getExpires());
+
+        $expires = $setCookie->getExpires();
+
+        $this->assertLessThanOrEqual($expiresMin, $expires);
+        $this->assertLessThanOrEqual($expiresMax, $expires);
 
         $this->restoreOriginalSessionIniSettings($ini);
     }
@@ -548,11 +554,17 @@ class PhpSessionPersistenceTest extends TestCase
             'foo' => 'bar',
         ], 'abcdef123456');
 
+        $expiresMin = time() + $lifetime;
         $response = $persistence->persistSession($session, new Response());
+        $expiresMax = time() + $lifetime;
 
         $setCookie = FigResponseCookies::get($response, session_name());
         $this->assertInstanceOf(SetCookie::class, $setCookie);
-        $this->assertSame(time() + $lifetime, $setCookie->getExpires());
+
+        $expires = $setCookie->getExpires();
+
+        $this->assertGreaterThanOrEqual($expiresMin, $expires);
+        $this->assertLessThanOrEqual($expiresMax, $expires);
 
         $this->restoreOriginalSessionIniSettings($ini);
     }

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -534,7 +534,7 @@ class PhpSessionPersistenceTest extends TestCase
 
         $expires = $setCookie->getExpires();
 
-        $this->assertLessThanOrEqual($expiresMin, $expires);
+        $this->assertGreaterThanOrEqual($expiresMin, $expires);
         $this->assertLessThanOrEqual($expiresMax, $expires);
 
         $this->restoreOriginalSessionIniSettings($ini);


### PR DESCRIPTION
The actual lifetime set in `persistsSession()` must be checked to fall between a range (using pre and post persist `time()`) and not using the post-persist `time()` as it could yield 1 second more that the actual persist call.