### PR TITLE
parse boolean ini settings when creating the response cookie

### DIFF
--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -739,8 +739,12 @@ class PhpSessionPersistenceTest extends TestCase
     /**
      * @dataProvider cookieSettingsProvider
      */
-    public function testSetCookieOnSettings($secureIni, $httpOnlyIni, $expectedSecure, $expectedHttpOnly)
-    {
+    public function testThatSetCookieCorrectlyInterpretsIniSettings(
+        $secureIni,
+        $httpOnlyIni,
+        $expectedSecure,
+        $expectedHttpOnly
+    ) {
         $ini = $this->applyCustomSessionOptions([
             'cookie_secure'   => $secureIni,
             'cookie_httponly' => $httpOnlyIni,

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -735,4 +735,48 @@ class PhpSessionPersistenceTest extends TestCase
 
         $this->restoreOriginalSessionIniSettings($ini);
     }
+
+    /**
+     * @dataProvider cookieSettingsProvider
+     */
+    public function testSetCookieOnSettings($secureIni, $httpOnlyIni, $expectedSecure, $expectedHttpOnly)
+    {
+        $ini = $this->applyCustomSessionOptions([
+            'cookie_secure'   => $secureIni,
+            'cookie_httponly' => $httpOnlyIni,
+        ]);
+
+        $persistence = new PhpSessionPersistence();
+
+        $createSessionCookie = new ReflectionMethod($persistence, 'createSessionCookie');
+        $createSessionCookie->setAccessible(true);
+
+        $setCookie = $createSessionCookie->invokeArgs(
+            $persistence,
+            ['SETCOOKIESESSIONID', 'set-cookie-test-value']
+        );
+
+        $this->assertSame($expectedSecure, $setCookie->getSecure());
+        $this->assertSame($expectedHttpOnly, $setCookie->getHttpOnly());
+
+        $this->restoreOriginalSessionIniSettings($ini);
+    }
+
+    public function cookieSettingsProvider()
+    {
+        // obvious input/results data are left (commented out) for reference
+        return [
+            //[false, false, false, false],
+            //[0, 0, false, false],
+            //['0', '0', false, false],
+            //['', '', false, false],
+            ['off', 'off', false, false],
+            ['Off', 'Off', false, false],
+            //[true, true, true, true],
+            //[1, 1, true, true],
+            //['1', '1', true, true],
+            //['on', 'on', true, true],
+            //['On', 'On', true, true],
+        ];
+    }
 }


### PR DESCRIPTION
The imported `SetCookie` class does not perform type-checking, so a ini value `Off` would be considere a truthy value when setting `secure` and `httpOnly` values in the response cookies.
- refactored the logic of set-cookie creation in a factory method
- added test case + provider