### PR TITLE
code refactoring plus commentary

### DIFF
--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -17,7 +17,6 @@ use Zend\Expressive\Session\SessionCookiePersistenceInterface;
 use Zend\Expressive\Session\SessionInterface;
 use Zend\Expressive\Session\SessionPersistenceInterface;
 
-use function array_merge;
 use function bin2hex;
 use function filemtime;
 use function getlastmod;


### PR DESCRIPTION
- moved the logic for setting the response cookie into own private method `addSessionCookie`
- moved the logic for adding cache headers to the response into own private method `addCacheHeaders`
- changed the `createSessionCookie` method to include the lifetime argument
- added commentary about cacheLimiter and cacheExpire (from php documentation), particularly highlight the fact that the cacheExpire integer value is meant for minutes and not for seconds (every time I look at "60 \* cacheExpire" for Max-Age computation I wonder why I added the "60 \* " in the first place for when I read the  "expire" word I always think about "seconds")
- moved the cacheLimiter property close to the related supported values static property

@weierophinney As this is a highly opinionated refactoring (It's my personal preference to have methods that clearly explain what happens), the first line you don't approve of you just close it! no explanation needed....kind regards

ps
I would also suggest to refactor
```
$sessionId = FigRequestCookies::get($request, session_name())->getValue() ?? '';
```
into a `getSessionIdFromRequest($request)`, again it's only my personal preference to avoid third-party library references in interface methods when possible. This would also simplify if that dependency is going to change (for instance I removed it and added the logic for request/response session cookie in the persistence implementation)