### PR TITLE
add support for configurable non-locking sessions

### DIFF
--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -23,6 +23,36 @@ Otherwise, you will need to map `Zend\Expressive\Session\SessionPersistenceInter
 to `Zend\Expressive\Session\Ext\PhpSessionPersistence` in your dependency
 injection container.
 
+### Enabling non locking sessions
+
+The default behaviour of the php session extension is to lock the session file
+until *session_write_close* is called - usually at the end of script execution -
+in order to safely store the session data. This has the side effect of blocking
+every other script that request access to the same session file as for instance
+when performing concurrent ajax calls in a Single Page Application. The php session
+extension allows us to unlock the session file using the extra option *read_and_close*
+in *session_start*.
+
+This option can be enabled using the following configuration:
+
+```php
+// file: data/session.global.php
+return [
+    'session' => [
+        'persistence' => [
+            'ext' => [
+                'non_locking' => true, // true|false, true => read_and_close = true
+            ],
+        ],
+    ],
+];
+```
+
+As for the php extension, we can use safely use this option only when we are sure
+that the session data won't be changed or when only one of the concurrent scripts
+may change it. The last script that changes and persists the session data will
+overwrite any previous change.
+
 ## Usage
 
 In most cases, usage will be via `Zend\Expressive\Session\SessionMiddleware`,

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -24,8 +24,8 @@ class ConfigProvider
             'aliases' => [
                 SessionPersistenceInterface::class => PhpSessionPersistence::class,
             ],
-            'invokables' => [
-                PhpSessionPersistence::class => PhpSessionPersistence::class,
+            'factories' => [
+                PhpSessionPersistence::class => PhpSessionPersistenceFactory::class,
             ],
         ];
     }

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -50,6 +50,7 @@ use const PHP_SESSION_ACTIVE;
 class PhpSessionPersistence implements SessionPersistenceInterface
 {
     /**
+     * Use non locking mode during session initialization?
      *
      * @var bool
      */

--- a/src/PhpSessionPersistenceFactory.php
+++ b/src/PhpSessionPersistenceFactory.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-session for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-session/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Session\Ext;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Create and return an instance of PhpSessionPersistence.
+ *
+ * In order to use non-locking sessions please provide a configuration entry
+ * like the following:
+ *
+ * <code>
+ * //...
+ * 'session' => [
+ *     'persistence' => [
+ *         'ext' => [
+ *             'non_locking' => true, // true|false
+ *         ],
+ *     ],
+ * ],
+ * //...
+ * <code>
+ */
+class PhpSessionPersistenceFactory
+{
+    public function __invoke(ContainerInterface $container) : PhpSessionPersistence
+    {
+        $config = $container->has('config') ? $container->get('config') : null;
+        $config = $config['session']['persistence']['ext'] ?? null;
+
+        return new PhpSessionPersistence(! empty($config['non_locking']));
+    }
+}

--- a/test/PhpSessionPersistenceFactoryTest.php
+++ b/test/PhpSessionPersistenceFactoryTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-session for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-session/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Session\Ext;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Session\Ext\PhpSessionPersistence;
+use Zend\Expressive\Session\Ext\PhpSessionPersistenceFactory;
+
+class PhpSessionPersistenceFactoryTest extends TestCase
+{
+    public function testFactoryConfigProducesPhpSessionPersistenceInterfaceService()
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $factory = new PhpSessionPersistenceFactory();
+
+        // test php-session-persistence with missing config
+        $container->has('config')->willReturn(false);
+        $persistence = $factory($container->reveal());
+        $this->assertInstanceOf(PhpSessionPersistence::class, $persistence);
+        $this->assertAttributeSame(false, 'nonLocking', $persistence);
+
+        // test php-session-persistence with non-locking config set to false and true
+        foreach ([false, true] as $nonLocking) {
+            $container->has('config')->willReturn(true);
+            $container->get('config')->willReturn([
+                'session' => [
+                    'persistence' => [
+                        'ext' => [
+                            'non_locking' => $nonLocking,
+                        ],
+                    ],
+                ],
+            ]);
+            $persistence = $factory($container->reveal());
+            $this->assertAttributeSame($nonLocking, 'nonLocking', $persistence);
+        }
+    }
+}

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -777,4 +777,77 @@ class PhpSessionPersistenceTest extends TestCase
         // phpcs:enable
         // @codingStandardsIgnoreEnd
     }
+
+    public function testNonLockingSessionIsClosedAfterInitialize()
+    {
+        $persistence = new PhpSessionPersistence(true);
+
+        $request = $this->createSessionCookieRequest('non-locking-session-id');
+        $session = $persistence->initializeSessionFromRequest($request);
+        $this->assertSame(PHP_SESSION_NONE, session_status());
+        $response = $persistence->persistSession($session, new Response());
+    }
+
+    public function testSessionIsOpenAfterInitializeWithFalseNonLockingSetting()
+    {
+        $persistence = new PhpSessionPersistence(false);
+
+        $request = $this->createSessionCookieRequest('locking-session-id');
+        $session = $persistence->initializeSessionFromRequest($request);
+        $this->assertSame(PHP_SESSION_ACTIVE, session_status());
+        $response = $persistence->persistSession($session, new Response());
+    }
+
+    public function testNonLockingSessionDataIsPersisted()
+    {
+        $sid = 'non-locking-session-id';
+
+        $name  = 'non-locking-foo';
+        $value = 'non-locking-bar';
+
+        $persistence = new PhpSessionPersistence(true);
+
+        $request = $this->createSessionCookieRequest($sid);
+        $session = $persistence->initializeSessionFromRequest($request);
+        $session->set($name, $value);
+        $response = $persistence->persistSession($session, new Response());
+
+        $_SESSION = null;
+
+        // reopens the session file and check the contents
+        session_id($sid);
+        session_start();
+        $this->assertArrayHasKey($name, $_SESSION);
+        $this->assertSame($value, $_SESSION[$name]);
+        session_write_close();
+    }
+
+    public function testNonLockingRegeneratedSessionIsPersisted()
+    {
+        $sid = 'non-locking-session-id';
+
+        $name  = 'regenerated-non-locking-foo';
+        $value = 'regenerated-non-locking-bar';
+
+        $persistence = new PhpSessionPersistence(true);
+
+        $request = $this->createSessionCookieRequest($sid);
+        $session = $persistence->initializeSessionFromRequest($request);
+        $session->set($name, $value);
+        $session = $session->regenerate();
+        $response = $persistence->persistSession($session, new Response());
+
+        // get the regenerated session id from the response session cookie
+        $setCookie = FigResponseCookies::get($response, session_name());
+        $regeneratedId = $setCookie->getValue();
+
+        $_SESSION = null;
+
+        // reopens the session file and check the contents
+        session_id($regeneratedId);
+        session_start();
+        $this->assertArrayHasKey($name, $_SESSION);
+        $this->assertSame($value, $_SESSION[$name]);
+        session_write_close();
+    }
 }


### PR DESCRIPTION
**Note:**
This is a port of my local implementation (which now differs a little from this repo), so I'll let it sit here for other developers tests and suggestions. I possibly forgot to port something at this late hour.

_Short explaination:_
- basically, if we have a session cookie in the request we open the session file and close it right after reading it with the php-documented `read_and_close` option. 
- In the persistSession phase, with the `non_locking` option "on" the session (file) is closed (see test cases): if the session is regenerated or we didn't have an initial opened session, the session is already (re)generated by previous code, so I added an "elseif" checking for the nonLocking property and if the session data changed, because we do not need to open the session file if there are no changes to write.
- I could have left the session status check off (`session_write_close' C code does that itself), but I believe this remind the developers that the session could be not active at that point, if there is no need for it to be so.

**TODO**
- add warnings and caveats (docs) about what can go wrong with non-locking sessions and advice users about when this option could be (more) safely utilized (session file locking was added for a reason!)
- translate configuration documentation from php-doc blocks into md docs
- test, test, test...   
(edited)
- i forgot, add public class constants for configuration keys?