### PR TITLE
Implement `InitializePersistenceIdInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- `PhpSessionPersistence` now implements `InitializeSessionIdInterface`, allowing access to the generated / regenerated 
+  session ID before the session is persisted.
 
 ### Changed
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,4 +14,8 @@
             <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>
+
+    <php>
+        <ini name="session.save_handler" value="files" />
+    </php>
 </phpunit>

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -12,6 +12,8 @@ use Dflydev\FigCookies\FigResponseCookies;
 use Dflydev\FigCookies\SetCookie;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Zend\Expressive\Session\GenerateIdPersistenceInterface;
+use Zend\Expressive\Session\InitializePersistenceIdInterface;
 use Zend\Expressive\Session\Session;
 use Zend\Expressive\Session\SessionCookiePersistenceInterface;
 use Zend\Expressive\Session\SessionInterface;
@@ -46,7 +48,7 @@ use const FILTER_VALIDATE_BOOLEAN;
  * During persistence, if the session regeneration flag is true, a new session
  * identifier is created, and the session re-started.
  */
-class PhpSessionPersistence implements SessionPersistenceInterface
+class PhpSessionPersistence implements InitializePersistenceIdInterface, SessionPersistenceInterface
 {
     /**
      * The time-to-live for cached session pages in minutes as specified in php
@@ -132,6 +134,18 @@ class PhpSessionPersistence implements SessionPersistenceInterface
         $response = $this->addCacheHeaders($response);
 
         return $response;
+    }
+
+    public function initializeId(SessionInterface $session): SessionInterface
+    {
+        $id = $session->getId();
+        if ('' === $id || $session->isRegenerated()) {
+            $session = new Session($session->toArray(), $this->generateSessionId());
+        }
+
+        session_id($session->getId());
+
+        return $session;
     }
 
     /**

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -777,4 +777,37 @@ class PhpSessionPersistenceTest extends TestCase
         // phpcs:enable
         // @codingStandardsIgnoreEnd
     }
+
+    public function testInitializeIdReturnsSessionWithId()
+    {
+        $persistence = new PhpSessionPersistence();
+        $session = new Session(['foo' => 'bar']);
+        $actual = $persistence->initializeId($session);
+
+        $this->assertNotSame($session, $actual);
+        $this->assertNotEmpty($actual->getId());
+        $this->assertSame(session_id(), $actual->getId());
+        $this->assertSame(['foo' => 'bar'], $actual->toArray());
+    }
+
+    public function testInitializeIdRegeneratesSessionId()
+    {
+        $persistence = new PhpSessionPersistence();
+        $session = new Session(['foo' => 'bar'], 'original-id');
+        $session = $session->regenerate();
+        $actual = $persistence->initializeId($session);
+
+        $this->assertNotEmpty($actual->getId());
+        $this->assertNotSame('original-id', $actual->getId());
+        $this->assertFalse($actual->isRegenerated());
+    }
+
+    public function testInitializeIdReturnsSessionUnaltered()
+    {
+        $persistence = new PhpSessionPersistence();
+        $session = new Session(['foo' => 'bar'], 'original-id');
+        $actual = $persistence->initializeId($session);
+
+        $this->assertSame($session, $actual);
+    }
 }


### PR DESCRIPTION
This PR adds the `InitializePersistenceIdInterface` from:
https://github.com/zendframework/zend-expressive-session/pull/38

The tests on this won't pass until that PR is merged and the composer.json here updated.