### PR TITLE
Isolate session on disk between test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /coveralls-upload.json
 /docs/html/
 /phpunit.xml
-/test/sess/
 /vendor/
 /zf-mkdoc-theme.tgz
 /zf-mkdoc-theme/

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -66,14 +66,6 @@ class PhpSessionPersistenceTest extends TestCase
             mkdir($this->sessionSavePath);
         }
 
-        // remove old session test files if any
-        $files = glob("{$this->sessionSavePath}/sess_*");
-        if ($files) {
-            foreach ($files as $file) {
-                unlink($file);
-            }
-        }
-
         $this->persistence = new PhpSessionPersistence();
     }
 
@@ -81,6 +73,14 @@ class PhpSessionPersistenceTest extends TestCase
     {
         session_write_close();
         $this->restoreOriginalSessionIniSettings($this->originalSessionSettings);
+
+        // remove old session test files if any
+        $files = glob("{$this->sessionSavePath}/sess_*");
+        if ($files) {
+            foreach ($files as $file) {
+                unlink($file);
+            }
+        }
     }
 
     public function startSession(string $id = null, array $options = [])
@@ -229,7 +229,7 @@ class PhpSessionPersistenceTest extends TestCase
     {
         $request = $this->createSessionCookieRequest('use-this-id');
         $session = $this->persistence->initializeSessionFromRequest($request);
-        $session->set('foo', __METHOD__ . time());
+        $session->set('foo', __METHOD__);
 
         $response = new Response();
         $returnedResponse = $this->persistence->persistSession($session, $response);


### PR DESCRIPTION
This prevent side-effects between test cases via session that might
or might not pre-exist on disk.

As discussed in https://github.com/zendframework/zend-expressive-session-ext/pull/44#discussion_r330647766. Once that other PR is merged, I'll rebase this one to remove that `time()` usage that won't be necessary anymore.

Do test improvements also require a CHANGELOG entry ?

Provide a narrative description of what you are trying to accomplish:

- [ ] Are you fixing a bug?
  - [ ] Detail how the bug is invoked currently.
  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [x] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
