### PR TITLE
destroy session on regenerate session when session is active

### DIFF
--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -25,6 +25,7 @@ use function getlastmod;
 use function gmdate;
 use function ini_get;
 use function random_bytes;
+use function session_destroy;
 use function session_id;
 use function session_name;
 use function session_start;
@@ -190,6 +191,10 @@ class PhpSessionPersistence implements InitializePersistenceIdInterface, Session
      */
     private function regenerateSession() : string
     {
+        if (PHP_SESSION_ACTIVE === session_status()) {
+            session_destroy();
+        }
+
         session_write_close();
         $id = $this->generateSessionId();
         $this->startSession($id, [

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -902,6 +902,23 @@ class PhpSessionPersistenceTest extends TestCase
         $this->assertFalse($actual->isRegenerated());
     }
 
+    public function testRegenerateWhenSessionAlreadyActiveDestroyExistingSessionFirst()
+    {
+        session_start();
+
+        $_SESSION['test'] = 'value';
+        $fileSession = realpath(session_save_path() . '/sess_' . session_id());
+
+        $this->assertTrue(file_exists($fileSession));
+
+        $persistence = new PhpSessionPersistence();
+        $session     = new Session(['foo' => 'bar']);
+        $session     = $session->regenerate();
+        $persistence->persistSession($session, new Response());
+
+        $this->assertFalse(file_exists($fileSession));
+    }
+
     public function testInitializeIdReturnsSessionUnaltered()
     {
         $persistence = new PhpSessionPersistence();

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -902,6 +902,9 @@ class PhpSessionPersistenceTest extends TestCase
         $this->assertFalse($actual->isRegenerated());
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testRegenerateWhenSessionAlreadyActiveDestroyExistingSessionFirst()
     {
         session_start();

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -902,11 +902,15 @@ class PhpSessionPersistenceTest extends TestCase
         $this->assertFalse($actual->isRegenerated());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testRegenerateWhenSessionAlreadyActiveDestroyExistingSessionFirst()
     {
+        $sessionName     = 'NOSESSIONCOOKIESESSID';
+        $sessionSavePath = __DIR__ . "/sess";
+
+        $ini = $this->applyCustomSessionOptions([
+            'name'      => $sessionName,
+            'save_path' => $sessionSavePath,
+        ]);
         session_start();
 
         $_SESSION['test'] = 'value';
@@ -920,6 +924,9 @@ class PhpSessionPersistenceTest extends TestCase
         $persistence->persistSession($session, new Response());
 
         $this->assertFalse(file_exists($fileSession));
+        @unlink(realpath(session_save_path() . '/sess_' . session_id()));
+
+        $this->restoreOriginalSessionIniSettings($ini);
     }
 
     public function testInitializeIdReturnsSessionUnaltered()


### PR DESCRIPTION
There is a use case when session already started before, and already set some value, eg: on csrf session data on a login form. When authenticate, it call the session regenerate, which session id changed, but left the old session not persisted (unset not applied as session id changed), so old session with the value remain in the disk. 

To avoid it, I think we can apply `session_destroy()` before `session_write_close()` whenever session is active. 